### PR TITLE
FIX(runtime): Tiny bug in VM monitoring/management

### DIFF
--- a/hotspot/src/share/vm/services/threadService.hpp
+++ b/hotspot/src/share/vm/services/threadService.hpp
@@ -85,7 +85,7 @@ public:
   static bool is_thread_cpu_time_enabled()    { return _thread_cpu_time_enabled; }
 
   static bool set_thread_allocated_memory_enabled(bool flag);
-  static bool is_thread_allocated_memory_enabled() { return _thread_cpu_time_enabled; }
+  static bool is_thread_allocated_memory_enabled() { return _thread_allocated_memory_enabled; }
 
   static jlong get_total_thread_count()       { return _total_threads_count->get_value(); }
   static jlong get_peak_thread_count()        { return _peak_threads_count->get_value(); }


### PR DESCRIPTION
Fix one tiny bug that is_thread_allocated_memory_enabled() returns wrong value.
backport from https://bugs.openjdk.java.net/browse/JDK-8215791

--story: 6991365

Contributed-by: linzang