### PR TITLE
FIX(runtime): solve compiler warning with get_shared_archive_path

### DIFF
--- a/hotspot/src/share/vm/runtime/arguments.cpp
+++ b/hotspot/src/share/vm/runtime/arguments.cpp
@@ -3882,10 +3882,7 @@ static char* get_shared_archive_path() {
   if (SharedArchiveFile == NULL) {
     shared_archive_path = Arguments::get_default_shared_archive_path();
   } else {
-    shared_archive_path = NEW_C_HEAP_ARRAY(char, strlen(SharedArchiveFile) + 1, mtInternal);
-    if (shared_archive_path != NULL) {
-      strncpy(shared_archive_path, SharedArchiveFile, strlen(SharedArchiveFile) + 1);
-    }
+    shared_archive_path = os::strdup(SharedArchiveFile, mtInternal);
   }
   return shared_archive_path;
 }


### PR DESCRIPTION
solve the compiler warning with strncpy:
specified bound depends on the length of the source argument [-Werror=stringop-overflow=]

--bug=88828381