### PR TITLE
Main changes

### DIFF
--- a/demo/fiber/oneshot_test/pom.xml
+++ b/demo/fiber/oneshot_test/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>oneshot_test</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.23</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.23</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>oneshot_test.jar</finalName><!-- 导出jar的名字 -->
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <createDependencyReducedPom>false</createDependencyReducedPom>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>org.example.Main</mainClass>
+                                    <!-- 主类的位置，例如上图文件，主类配置应为： -->
+                                    <!-- <mainClass>top.nihilwater.App</mainClass> -->
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/demo/fiber/oneshot_test/src/main/java/org/example/Main.java
+++ b/demo/fiber/oneshot_test/src/main/java/org/example/Main.java
@@ -1,0 +1,264 @@
+package org.example;
+
+/*
+ * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+//import jdk.internal.vm.Continuation;
+//import jdk.internal.vm.ContinuationScope;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class Main {
+    static final ContinuationScope SCOPE = new ContinuationScope() { };
+
+    static class Arg {
+        volatile int field;
+    }
+
+    /**
+     * A recursive task that optionally yields when the stack gets to a specific
+     * depth. If continued after yielding, it runs to completion.
+     */
+    static class Yielder implements Runnable {
+        private final int paramCount;
+        private final int maxDepth;
+        private final boolean yieldAtLimit;
+
+        private Yielder(int paramCount, int maxDepth, boolean yieldAtLimit) {
+            if (paramCount < 1 || paramCount > 3)
+                throw new IllegalArgumentException();
+            this.paramCount = paramCount;
+            this.maxDepth = maxDepth;
+            this.yieldAtLimit = yieldAtLimit;
+        }
+
+        @Override
+        public void run() {
+            switch (paramCount) {
+                case 1: run1(maxDepth); break;
+                case 2: run2(maxDepth, new Arg()); break;
+                case 3: run3(maxDepth, new Arg(), new Arg()); break;
+                default: throw new Error("should not happen");
+            }
+        }
+
+        private void run1(int depth) {
+            if (depth > 0) {
+                run1(depth - 1);
+            } if (depth == 0) {
+                if (yieldAtLimit) Continuation.yield(SCOPE);
+            }
+        }
+
+        private void run2(int depth, Arg arg2) {
+            if (depth > 0) {
+                run2(depth - 1, arg2);
+            } if (depth == 0) {
+                if (yieldAtLimit) Continuation.yield(SCOPE);
+            } else {
+                // never executed
+                arg2.field = 0;
+            }
+        }
+
+        private void run3(int depth, Arg arg2, Arg arg3) {
+            if (depth > 0) {
+                run3(depth - 1, arg2, arg3);
+            } if (depth == 0) {
+                if (yieldAtLimit) Continuation.yield(SCOPE);
+            } else {
+                // never executed
+                arg2.field = 0;
+                arg3.field = 0;
+            }
+        }
+
+        static Continuation continuation(int paramCount, int maxDepth,
+                                         boolean yieldAtLimit) {
+            Runnable task = new Yielder(paramCount, maxDepth, yieldAtLimit);
+            return new Continuation(SCOPE, task);
+        }
+    }
+
+    /**
+     * A recursive task that optionally yields before and/or after each call.
+     */
+    static class Stepper implements Runnable {
+        private final int paramCount;
+        private final int maxDepth;
+        private final boolean yieldBefore;
+        private final boolean yieldAfter;
+
+        private Stepper(int paramCount,
+                        int maxDepth,
+                        boolean yieldBefore,
+                        boolean yieldAfter) {
+            this.paramCount = paramCount;
+            this.maxDepth = maxDepth;
+            this.yieldBefore = yieldBefore;
+            this.yieldAfter = yieldAfter;
+        }
+
+        public void run() {
+            switch (paramCount) {
+                case 1: run1(maxDepth); break;
+                case 2: run2(maxDepth, new Arg()); break;
+                case 3: run3(maxDepth, new Arg(), new Arg()); break;
+                default: throw new Error("should not happen");
+            }
+        }
+
+        private void run1(int depth) {
+            if (depth > 0) {
+                if (yieldBefore) Continuation.yield(SCOPE);
+                run1(depth - 1);
+                if (yieldAfter) Continuation.yield(SCOPE);
+            }
+        }
+
+        private void run2(int depth, Arg arg2) {
+            if (depth > 0) {
+                if (yieldBefore) Continuation.yield(SCOPE);
+                run2(depth - 1, arg2);
+                if (yieldAfter) Continuation.yield(SCOPE);
+            } else if (depth < 0) {
+                // never executed
+                arg2.field = 0;
+            }
+        }
+
+        private void run3(int depth, Arg arg2, Arg arg3) {
+            if (depth > 0) {
+                if (yieldBefore) Continuation.yield(SCOPE);
+                run3(depth - 1, arg2, arg3);
+                if (yieldAfter) Continuation.yield(SCOPE);
+            } else if (depth < 0) {
+                // never executed
+                arg2.field = 0;
+                arg3.field = 0;
+            }
+        }
+
+        static Continuation continuation(int paramCount, int maxDepth,
+                                         boolean yieldBefore, boolean yieldAfter) {
+            Runnable task = new Stepper(paramCount, maxDepth, yieldBefore, yieldAfter);
+            return new Continuation(SCOPE, task);
+        }
+    }
+
+    @Param({"1", "2", "3"})
+    public int paramCount;
+
+    @Param({"5", "10", "20", "100"})
+    public int stackDepth;
+
+    /**
+     * Creates and run continuation that does not yield.
+     */
+    @Benchmark
+    public void noYield() {
+        Continuation cont = Yielder.continuation(paramCount, stackDepth, false);
+        cont.run();
+        if (!cont.isDone())
+            throw new RuntimeException("continuation not done???");
+    }
+
+    /**
+     * Creates and runs a continuation that yields at a given stack depth.
+     */
+    @Benchmark
+    public void yield() {
+        Continuation cont = Yielder.continuation(paramCount, stackDepth, true);
+        cont.run();
+        if (cont.isDone())
+            throw new RuntimeException("continuation done???");
+    }
+
+    /**
+     * Creates and runs a continuation that yields at a given stack depth, it is
+     * then continued to run to completion.
+     */
+    @Benchmark
+    public void yieldThenContinue() {
+        Continuation cont = Yielder.continuation(paramCount, stackDepth, true);
+        cont.run();
+        cont.run();  // continue
+        if (!cont.isDone())
+            throw new RuntimeException("continuation not done???");
+    }
+
+    /**
+     * Creates and runs a continuation to the given stack depth, yielding before
+     * each call.
+     */
+    @Benchmark
+    public void yieldBeforeEachCall() {
+        Continuation cont = Stepper.continuation(paramCount, stackDepth, true, false);
+        while (!cont.isDone()) {
+            cont.run();
+        }
+    }
+
+    /**
+     * Creates and runs a continuation to the given stack depth, yielding after
+     * each call.
+     */
+    @Benchmark
+    public void yieldAfterEachCall() {
+        Continuation cont = Stepper.continuation(paramCount, stackDepth, false, true);
+        while (!cont.isDone()) {
+            cont.run();
+        }
+    }
+
+    /**
+     * Creates and runs a continuation to the given stack depth, yielding before
+     * and after each call.
+     */
+    @Benchmark
+    public void yieldBeforeAndAfterEachCall() {
+        Continuation cont = Stepper.continuation(paramCount, stackDepth, true, true);
+        while (!cont.isDone()) {
+            cont.run();
+        }
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(Main.class.getSimpleName())
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+}

--- a/demo/fiber/oneshot_test/src/main/java/org/example/oneshot_test_result.txt
+++ b/demo/fiber/oneshot_test/src/main/java/org/example/oneshot_test_result.txt
@@ -1,0 +1,3520 @@
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.noYield
+# Parameters: (paramCount = 1, stackDepth = 5)
+
+# Run progress: 0.00% complete, ETA 00:12:00
+# Fork: 1 of 1
+# Warmup Iteration   1: 344.794 ns/op
+# Warmup Iteration   2: 613.688 ns/op
+# Warmup Iteration   3: 288.593 ns/op
+# Warmup Iteration   4: 634.217 ns/op
+# Warmup Iteration   5: 254.509 ns/op
+Iteration   1: 275.484 ns/op
+Iteration   2: 721.226 ns/op
+Iteration   3: 714.601 ns/op
+Iteration   4: 363.549 ns/op
+Iteration   5: 262.616 ns/op
+
+
+Result "org.example.Main.noYield":
+467.495 ±(99.9%) 892.920 ns/op [Average]
+(min, avg, max) = (262.616, 467.495, 721.226), stdev = 231.888
+CI (99.9%): [≈ 0, 1360.415] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.noYield
+# Parameters: (paramCount = 1, stackDepth = 10)
+
+# Run progress: 1.39% complete, ETA 00:13:11
+# Fork: 1 of 1
+# Warmup Iteration   1: 276.410 ns/op
+# Warmup Iteration   2: 262.324 ns/op
+# Warmup Iteration   3: 298.936 ns/op
+# Warmup Iteration   4: 216.769 ns/op
+# Warmup Iteration   5: 210.867 ns/op
+Iteration   1: 224.948 ns/op
+Iteration   2: 239.443 ns/op
+Iteration   3: 222.748 ns/op
+Iteration   4: 236.369 ns/op
+Iteration   5: 196.388 ns/op
+
+
+Result "org.example.Main.noYield":
+223.979 ±(99.9%) 65.472 ns/op [Average]
+(min, avg, max) = (196.388, 223.979, 239.443), stdev = 17.003
+CI (99.9%): [158.507, 289.451] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.noYield
+# Parameters: (paramCount = 1, stackDepth = 20)
+
+# Run progress: 2.78% complete, ETA 00:12:49
+# Fork: 1 of 1
+# Warmup Iteration   1: 285.603 ns/op
+# Warmup Iteration   2: 268.106 ns/op
+# Warmup Iteration   3: 273.754 ns/op
+# Warmup Iteration   4: 256.659 ns/op
+# Warmup Iteration   5: 259.845 ns/op
+Iteration   1: 247.966 ns/op
+Iteration   2: 268.414 ns/op
+Iteration   3: 256.682 ns/op
+Iteration   4: 265.851 ns/op
+Iteration   5: 217.296 ns/op
+
+
+Result "org.example.Main.noYield":
+251.242 ±(99.9%) 79.406 ns/op [Average]
+(min, avg, max) = (217.296, 251.242, 268.414), stdev = 20.622
+CI (99.9%): [171.836, 330.648] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.noYield
+# Parameters: (paramCount = 1, stackDepth = 100)
+
+# Run progress: 4.17% complete, ETA 00:12:29
+# Fork: 1 of 1
+# Warmup Iteration   1: 562.398 ns/op
+# Warmup Iteration   2: 530.574 ns/op
+# Warmup Iteration   3: 540.767 ns/op
+# Warmup Iteration   4: 530.039 ns/op
+# Warmup Iteration   5: 622.601 ns/op
+Iteration   1: 551.122 ns/op
+Iteration   2: 611.580 ns/op
+Iteration   3: 585.527 ns/op
+Iteration   4: 595.996 ns/op
+Iteration   5: 609.017 ns/op
+
+
+Result "org.example.Main.noYield":
+590.648 ±(99.9%) 94.177 ns/op [Average]
+(min, avg, max) = (551.122, 590.648, 611.580), stdev = 24.457
+CI (99.9%): [496.471, 684.825] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.noYield
+# Parameters: (paramCount = 2, stackDepth = 5)
+
+# Run progress: 5.56% complete, ETA 00:12:13
+# Fork: 1 of 1
+# Warmup Iteration   1: 335.789 ns/op
+# Warmup Iteration   2: 317.608 ns/op
+# Warmup Iteration   3: 315.680 ns/op
+# Warmup Iteration   4: 281.744 ns/op
+# Warmup Iteration   5: 301.463 ns/op
+Iteration   1: 285.923 ns/op
+Iteration   2: 285.661 ns/op
+Iteration   3: 253.625 ns/op
+Iteration   4: 254.003 ns/op
+Iteration   5: 239.441 ns/op
+
+
+Result "org.example.Main.noYield":
+263.731 ±(99.9%) 80.775 ns/op [Average]
+(min, avg, max) = (239.441, 263.731, 285.923), stdev = 20.977
+CI (99.9%): [182.956, 344.506] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.noYield
+# Parameters: (paramCount = 2, stackDepth = 10)
+
+# Run progress: 6.94% complete, ETA 00:12:00
+# Fork: 1 of 1
+# Warmup Iteration   1: 342.037 ns/op
+# Warmup Iteration   2: 318.868 ns/op
+# Warmup Iteration   3: 278.047 ns/op
+# Warmup Iteration   4: 297.428 ns/op
+# Warmup Iteration   5: 329.049 ns/op
+Iteration   1: 348.839 ns/op
+Iteration   2: 332.762 ns/op
+Iteration   3: 342.727 ns/op
+Iteration   4: 344.790 ns/op
+Iteration   5: 343.683 ns/op
+
+
+Result "org.example.Main.noYield":
+342.560 ±(99.9%) 22.917 ns/op [Average]
+(min, avg, max) = (332.762, 342.560, 348.839), stdev = 5.951
+CI (99.9%): [319.643, 365.477] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.noYield
+# Parameters: (paramCount = 2, stackDepth = 20)
+
+# Run progress: 8.33% complete, ETA 00:11:48
+# Fork: 1 of 1
+# Warmup Iteration   1: 489.283 ns/op
+# Warmup Iteration   2: 429.440 ns/op
+# Warmup Iteration   3: 421.222 ns/op
+# Warmup Iteration   4: 459.196 ns/op
+# Warmup Iteration   5: 451.432 ns/op
+Iteration   1: 437.762 ns/op
+Iteration   2: 388.382 ns/op
+Iteration   3: 435.677 ns/op
+Iteration   4: 464.658 ns/op
+Iteration   5: 414.951 ns/op
+
+
+Result "org.example.Main.noYield":
+428.286 ±(99.9%) 109.549 ns/op [Average]
+(min, avg, max) = (388.382, 428.286, 464.658), stdev = 28.450
+CI (99.9%): [318.737, 537.835] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.noYield
+# Parameters: (paramCount = 2, stackDepth = 100)
+
+# Run progress: 9.72% complete, ETA 00:11:37
+# Fork: 1 of 1
+# Warmup Iteration   1: 1249.058 ns/op
+# Warmup Iteration   2: 1256.810 ns/op
+# Warmup Iteration   3: 1258.754 ns/op
+# Warmup Iteration   4: 1315.899 ns/op
+# Warmup Iteration   5: 1263.980 ns/op
+Iteration   1: 1320.278 ns/op
+Iteration   2: 1282.888 ns/op
+Iteration   3: 1144.886 ns/op
+Iteration   4: 1078.295 ns/op
+Iteration   5: 1082.201 ns/op
+
+
+Result "org.example.Main.noYield":
+1181.710 ±(99.9%) 436.463 ns/op [Average]
+(min, avg, max) = (1078.295, 1181.710, 1320.278), stdev = 113.348
+CI (99.9%): [745.247, 1618.172] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.noYield
+# Parameters: (paramCount = 3, stackDepth = 5)
+
+# Run progress: 11.11% complete, ETA 00:11:25
+# Fork: 1 of 1
+# Warmup Iteration   1: 342.527 ns/op
+# Warmup Iteration   2: 363.121 ns/op
+# Warmup Iteration   3: 324.957 ns/op
+# Warmup Iteration   4: 305.481 ns/op
+# Warmup Iteration   5: 270.086 ns/op
+Iteration   1: 270.225 ns/op
+Iteration   2: 295.237 ns/op
+Iteration   3: 316.071 ns/op
+Iteration   4: 343.401 ns/op
+Iteration   5: 310.244 ns/op
+
+
+Result "org.example.Main.noYield":
+307.035 ±(99.9%) 103.836 ns/op [Average]
+(min, avg, max) = (270.225, 307.035, 343.401), stdev = 26.966
+CI (99.9%): [203.199, 410.872] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.noYield
+# Parameters: (paramCount = 3, stackDepth = 10)
+
+# Run progress: 12.50% complete, ETA 00:11:13
+# Fork: 1 of 1
+# Warmup Iteration   1: 474.640 ns/op
+# Warmup Iteration   2: 443.710 ns/op
+# Warmup Iteration   3: 445.083 ns/op
+# Warmup Iteration   4: 356.533 ns/op
+# Warmup Iteration   5: 421.235 ns/op
+Iteration   1: 355.497 ns/op
+Iteration   2: 395.940 ns/op
+Iteration   3: 398.198 ns/op
+Iteration   4: 394.448 ns/op
+Iteration   5: 372.826 ns/op
+
+
+Result "org.example.Main.noYield":
+383.382 ±(99.9%) 71.748 ns/op [Average]
+(min, avg, max) = (355.497, 383.382, 398.198), stdev = 18.633
+CI (99.9%): [311.634, 455.129] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.noYield
+# Parameters: (paramCount = 3, stackDepth = 20)
+
+# Run progress: 13.89% complete, ETA 00:11:02
+# Fork: 1 of 1
+# Warmup Iteration   1: 600.814 ns/op
+# Warmup Iteration   2: 570.779 ns/op
+# Warmup Iteration   3: 593.038 ns/op
+# Warmup Iteration   4: 575.287 ns/op
+# Warmup Iteration   5: 591.003 ns/op
+Iteration   1: 586.966 ns/op
+Iteration   2: 599.213 ns/op
+Iteration   3: 600.599 ns/op
+Iteration   4: 583.702 ns/op
+Iteration   5: 588.771 ns/op
+
+
+Result "org.example.Main.noYield":
+591.850 ±(99.9%) 29.230 ns/op [Average]
+(min, avg, max) = (583.702, 591.850, 600.599), stdev = 7.591
+CI (99.9%): [562.621, 621.080] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.noYield
+# Parameters: (paramCount = 3, stackDepth = 100)
+
+# Run progress: 15.28% complete, ETA 00:10:51
+# Fork: 1 of 1
+# Warmup Iteration   1: 2035.233 ns/op
+# Warmup Iteration   2: 1640.356 ns/op
+# Warmup Iteration   3: 1855.962 ns/op
+# Warmup Iteration   4: 1835.350 ns/op
+# Warmup Iteration   5: 1867.356 ns/op
+Iteration   1: 1715.980 ns/op
+Iteration   2: 1781.699 ns/op
+Iteration   3: 1792.873 ns/op
+Iteration   4: 1812.307 ns/op
+Iteration   5: 2021.704 ns/op
+
+
+Result "org.example.Main.noYield":
+1824.913 ±(99.9%) 445.936 ns/op [Average]
+(min, avg, max) = (1715.980, 1824.913, 2021.704), stdev = 115.808
+CI (99.9%): [1378.977, 2270.848] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yield
+# Parameters: (paramCount = 1, stackDepth = 5)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+<failure>
+
+java.lang.RuntimeException: continuation done???
+at org.example.Main.yield(Main.java:204)
+at org.example.generated.Main_yield_jmhTest.yield_avgt_jmhStub(Main_yield_jmhTest.java:186)
+at org.example.generated.Main_yield_jmhTest.yield_AverageTime(Main_yield_jmhTest.java:150)
+at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:67)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+at java.lang.Thread.run(Thread.java:849)
+
+
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007fa9a6500000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007fa9db900000, 12288, 0) failed; error='无法分配内存' (errno=12)
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+[thread 140367510894144 also had an error]
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2822.log
+<forked VM failed with exit code 1>
+<stdout last='20 lines'>
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+[thread 140367510894144 also had an error]
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2822.log
+</stdout>
+<stderr last='20 lines'>
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007fa9a6500000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007fa9db900000, 12288, 0) failed; error='无法分配内存' (errno=12)
+</stderr>
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yield
+# Parameters: (paramCount = 1, stackDepth = 10)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+<failure>
+
+java.lang.RuntimeException: continuation done???
+at org.example.Main.yield(Main.java:204)
+at org.example.generated.Main_yield_jmhTest.yield_avgt_jmhStub(Main_yield_jmhTest.java:186)
+at org.example.generated.Main_yield_jmhTest.yield_AverageTime(Main_yield_jmhTest.java:150)
+at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:67)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+at java.lang.Thread.run(Thread.java:849)
+
+
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f75ce100000, 12288, 0) failed; error='无法分配内存' (errno=12)
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2845.log
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f75ac700000, 12288, 0) failed; error='无法分配内存' (errno=12)
+[thread 140143381968448 also had an error]
+<forked VM failed with exit code 1>
+<stdout last='20 lines'>
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2845.log
+[thread 140143381968448 also had an error]
+</stdout>
+<stderr last='20 lines'>
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f75ce100000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f75ac700000, 12288, 0) failed; error='无法分配内存' (errno=12)
+</stderr>
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yield
+# Parameters: (paramCount = 1, stackDepth = 20)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+<failure>
+
+java.lang.RuntimeException: continuation done???
+at org.example.Main.yield(Main.java:204)
+at org.example.generated.Main_yield_jmhTest.yield_avgt_jmhStub(Main_yield_jmhTest.java:186)
+at org.example.generated.Main_yield_jmhTest.yield_AverageTime(Main_yield_jmhTest.java:150)
+at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:67)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+at java.lang.Thread.run(Thread.java:849)
+
+
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007fd1e3b00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2868.log
+OpenJDK 64-Bit Server VM warning: [thread 140538412004928 also had an error]
+INFO: os::commit_memory(0x00007fd1a6100000, 12288, 0) failed; error='无法分配内存' (errno=12)
+<forked VM failed with exit code 1>
+<stdout last='20 lines'>
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2868.log
+[thread 140538412004928 also had an error]
+</stdout>
+<stderr last='20 lines'>
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007fd1e3b00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007fd1a6100000, 12288, 0) failed; error='无法分配内存' (errno=12)
+</stderr>
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yield
+# Parameters: (paramCount = 1, stackDepth = 100)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+<failure>
+
+java.lang.RuntimeException: continuation done???
+at org.example.Main.yield(Main.java:204)
+at org.example.generated.Main_yield_jmhTest.yield_avgt_jmhStub(Main_yield_jmhTest.java:186)
+at org.example.generated.Main_yield_jmhTest.yield_AverageTime(Main_yield_jmhTest.java:150)
+at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:67)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+at java.lang.Thread.run(Thread.java:849)
+
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f7311900000, 12288, 0) failed; error='无法分配内存' (errno=12)
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2891.log
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f733f100000, 12288, 0) failed; error='无法分配内存' (errno=12)
+[thread 140132957025856 also had an error]
+<forked VM failed with exit code 1>
+<stdout last='20 lines'>
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2891.log
+[thread 140132957025856 also had an error]
+</stdout>
+<stderr last='20 lines'>
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f7311900000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f733f100000, 12288, 0) failed; error='无法分配内存' (errno=12)
+</stderr>
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yield
+# Parameters: (paramCount = 2, stackDepth = 5)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+<failure>
+
+java.lang.RuntimeException: continuation done???
+at org.example.Main.yield(Main.java:204)
+at org.example.generated.Main_yield_jmhTest.yield_avgt_jmhStub(Main_yield_jmhTest.java:186)
+at org.example.generated.Main_yield_jmhTest.yield_AverageTime(Main_yield_jmhTest.java:150)
+at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:67)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+at java.lang.Thread.run(Thread.java:849)
+
+
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Ser#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2914.log
+ver VM warning: INFO: os::commit_memory(0x00007fb790040000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007fb7b0300000, 12288, 0) failed; error='无法分配内存' (errno=12)
+[thread 140426912724544 also had an error]
+<forked VM failed with exit code 1>
+<stdout last='20 lines'>
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2914.log
+[thread 140426912724544 also had an error]
+</stdout>
+<stderr last='20 lines'>
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007fb790040000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007fb7b0300000, 12288, 0) failed; error='无法分配内存' (errno=12)
+</stderr>
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yield
+# Parameters: (paramCount = 2, stackDepth = 10)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+<failure>
+
+java.lang.RuntimeException: continuation done???
+at org.example.Main.yield(Main.java:204)
+at org.example.generated.Main_yield_jmhTest.yield_avgt_jmhStub(Main_yield_jmhTest.java:186)
+at org.example.generated.Main_yield_jmhTest.yield_AverageTime(Main_yield_jmhTest.java:150)
+at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:67)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+at java.lang.Thread.run(Thread.java:849)
+
+
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007ff3e4d00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007ff40d900000, 12288, 0) failed; error='无法分配内存' (errno=12)
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2937.log
+[thread 140686177334848 also had an error]
+<forked VM failed with exit code 1>
+<stdout last='20 lines'>
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2937.log
+[thread 140686177334848 also had an error]
+</stdout>
+<stderr last='20 lines'>
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007ff3e4d00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007ff40d900000, 12288, 0) failed; error='无法分配内存' (errno=12)
+</stderr>
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yield
+# Parameters: (paramCount = 2, stackDepth = 20)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+<failure>
+
+java.lang.RuntimeException: continuation done???
+at org.example.Main.yield(Main.java:204)
+at org.example.generated.Main_yield_jmhTest.yield_avgt_jmhStub(Main_yield_jmhTest.java:186)
+at org.example.generated.Main_yield_jmhTest.yield_AverageTime(Main_yield_jmhTest.java:150)
+at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:67)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+at java.lang.Thread.run(Thread.java:849)
+
+
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2960.log
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f380bd00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+[thread 139877794444864 also had an error]
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f37d6300000, 12288, 0) failed; error='无法分配内存' (errno=12)
+<forked VM failed with exit code 1>
+<stdout last='20 lines'>
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2960.log
+[thread 139877794444864 also had an error]
+</stdout>
+<stderr last='20 lines'>
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f380bd00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f37d6300000, 12288, 0) failed; error='无法分配内存' (errno=12)
+</stderr>
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yield
+# Parameters: (paramCount = 2, stackDepth = 100)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: 39133.672 ns/op
+# Warmup Iteration   2: OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+<failure>
+
+java.lang.RuntimeException: continuation done???
+at org.example.Main.yield(Main.java:204)
+at org.example.generated.Main_yield_jmhTest.yield_avgt_jmhStub(Main_yield_jmhTest.java:186)
+at org.example.generated.Main_yield_jmhTest.yield_AverageTime(Main_yield_jmhTest.java:150)
+at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:67)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+at java.lang.Thread.run(Thread.java:849)
+
+
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f6560d00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2983.log
+[thread 140074018666048 also had an error]
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f6586100000, 12288, 0) failed; error='无法分配内存' (errno=12)
+<forked VM failed with exit code 1>
+<stdout last='20 lines'>
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid2983.log
+[thread 140074018666048 also had an error]
+</stdout>
+<stderr last='20 lines'>
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f6560d00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f6586100000, 12288, 0) failed; error='无法分配内存' (errno=12)
+</stderr>
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yield
+# Parameters: (paramCount = 3, stackDepth = 5)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+<failure>
+
+java.lang.RuntimeException: continuation done???
+at org.example.Main.yield(Main.java:204)
+at org.example.generated.Main_yield_jmhTest.yield_avgt_jmhStub(Main_yield_jmhTest.java:186)
+at org.example.generated.Main_yield_jmhTest.yield_AverageTime(Main_yield_jmhTest.java:150)
+at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:67)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+at java.lang.Thread.run(Thread.java:849)
+
+
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f5364d00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f5392700000, 12288, 0) failed; error='无法分配内存' (errno=12)
+#
+[thread 139996916872768 also had an error]
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid3006.log
+<forked VM failed with exit code 1>
+<stdout last='20 lines'>
+#
+[thread 139996916872768 also had an error]
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid3006.log
+</stdout>
+<stderr last='20 lines'>
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f5364d00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f5392700000, 12288, 0) failed; error='无法分配内存' (errno=12)
+</stderr>
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yield
+# Parameters: (paramCount = 3, stackDepth = 10)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+<failure>
+
+java.lang.RuntimeException: continuation done???
+at org.example.Main.yield(Main.java:204)
+at org.example.generated.Main_yield_jmhTest.yield_avgt_jmhStub(Main_yield_jmhTest.java:186)
+at org.example.generated.Main_yield_jmhTest.yield_AverageTime(Main_yield_jmhTest.java:150)
+at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:67)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+at java.lang.Thread.run(Thread.java:849)
+
+
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f1620500000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f1641b00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+#
+[thread 139733569107520 also had an error]
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid3029.log
+<forked VM failed with exit code 1>
+<stdout last='20 lines'>
+#
+[thread 139733569107520 also had an error]
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid3029.log
+</stdout>
+<stderr last='20 lines'>
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f1620500000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f1641b00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+</stderr>
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yield
+# Parameters: (paramCount = 3, stackDepth = 20)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+<failure>
+
+java.lang.RuntimeException: continuation done???
+at org.example.Main.yield(Main.java:204)
+at org.example.generated.Main_yield_jmhTest.yield_avgt_jmhStub(Main_yield_jmhTest.java:186)
+at org.example.generated.Main_yield_jmhTest.yield_AverageTime(Main_yield_jmhTest.java:150)
+at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:67)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+at java.lang.Thread.run(Thread.java:849)
+
+
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f0cd8f00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f0d06300000, 12288, 0) failed; error='无法分配内存' (errno=12)
+#
+[thread 139693916157504 also had an error]
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid3052.log
+<forked VM failed with exit code 1>
+<stdout last='20 lines'>
+#
+[thread 139693916157504 also had an error]
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid3052.log
+</stdout>
+<stderr last='20 lines'>
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f0cd8f00000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f0d06300000, 12288, 0) failed; error='无法分配内存' (errno=12)
+</stderr>
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yield
+# Parameters: (paramCount = 3, stackDepth = 100)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+<failure>
+
+java.lang.RuntimeException: continuation done???
+at org.example.Main.yield(Main.java:204)
+at org.example.generated.Main_yield_jmhTest.yield_avgt_jmhStub(Main_yield_jmhTest.java:186)
+at org.example.generated.Main_yield_jmhTest.yield_AverageTime(Main_yield_jmhTest.java:150)
+at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
+at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:67)
+at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
+at java.lang.reflect.Method.invoke(Method.java:498)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:453)
+at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:437)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
+at java.util.concurrent.FutureTask.run(FutureTask.java:266)
+at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
+at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
+at java.lang.Thread.run(Thread.java:849)
+
+
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f3b80700000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f3b68000000, 12288, 0) failed; error='无法分配内存' (errno=12)#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid3075.log
+
+[thread 139893125674560 also had an error]
+<forked VM failed with exit code 1>
+<stdout last='20 lines'>
+#
+# There is insufficient memory for the Java Runtime Environment to continue.
+# Native memory allocation (mmap) failed to map 12288 bytes for committing reserved memory.
+# An error report file with more information is saved as:
+# /home/jong/WorkSpace/TencentKona-8-KonaFiber/hs_err_pid3075.log
+[thread 139893125674560 also had an error]
+</stdout>
+<stderr last='20 lines'>
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to protect stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: Attempt to deallocate stack guard pages failed.
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f3b80700000, 12288, 0) failed; error='无法分配内存' (errno=12)
+OpenJDK 64-Bit Server VM warning: INFO: os::commit_memory(0x00007f3b68000000, 12288, 0) failed; error='无法分配内存' (errno=12)
+</stderr>
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldAfterEachCall
+# Parameters: (paramCount = 1, stackDepth = 5)
+
+# Run progress: 16.67% complete, ETA 00:10:40
+# Fork: 1 of 1
+# Warmup Iteration   1: 633.105 ns/op
+# Warmup Iteration   2: 599.768 ns/op
+# Warmup Iteration   3: 617.192 ns/op
+# Warmup Iteration   4: 613.033 ns/op
+# Warmup Iteration   5: 591.934 ns/op
+Iteration   1: 613.078 ns/op
+Iteration   2: 646.231 ns/op
+Iteration   3: 624.395 ns/op
+Iteration   4: 813.764 ns/op
+Iteration   5: 734.499 ns/op
+
+
+Result "org.example.Main.yieldAfterEachCall":
+686.393 ±(99.9%) 329.952 ns/op [Average]
+(min, avg, max) = (613.078, 686.393, 813.764), stdev = 85.687
+CI (99.9%): [356.441, 1016.345] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldAfterEachCall
+# Parameters: (paramCount = 1, stackDepth = 10)
+
+# Run progress: 18.06% complete, ETA 00:11:56
+# Fork: 1 of 1
+# Warmup Iteration   1: 935.164 ns/op
+# Warmup Iteration   2: 833.538 ns/op
+# Warmup Iteration   3: 743.274 ns/op
+# Warmup Iteration   4: 946.452 ns/op
+# Warmup Iteration   5: 1159.729 ns/op
+Iteration   1: 1107.052 ns/op
+Iteration   2: 1165.489 ns/op
+Iteration   3: 1047.795 ns/op
+Iteration   4: 911.004 ns/op
+Iteration   5: 940.109 ns/op
+
+
+Result "org.example.Main.yieldAfterEachCall":
+1034.290 ±(99.9%) 416.330 ns/op [Average]
+(min, avg, max) = (911.004, 1034.290, 1165.489), stdev = 108.120
+CI (99.9%): [617.960, 1450.620] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldAfterEachCall
+# Parameters: (paramCount = 1, stackDepth = 20)
+
+# Run progress: 19.44% complete, ETA 00:11:39
+# Fork: 1 of 1
+# Warmup Iteration   1: 1480.013 ns/op
+# Warmup Iteration   2: 1510.003 ns/op
+# Warmup Iteration   3: 1357.380 ns/op
+# Warmup Iteration   4: 1384.130 ns/op
+# Warmup Iteration   5: 1390.445 ns/op
+Iteration   1: 1249.057 ns/op
+Iteration   2: 1199.178 ns/op
+Iteration   3: 1192.916 ns/op
+Iteration   4: 1462.204 ns/op
+Iteration   5: 1318.867 ns/op
+
+
+Result "org.example.Main.yieldAfterEachCall":
+1284.444 ±(99.9%) 429.150 ns/op [Average]
+(min, avg, max) = (1192.916, 1284.444, 1462.204), stdev = 111.449
+CI (99.9%): [855.295, 1713.594] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldAfterEachCall
+# Parameters: (paramCount = 1, stackDepth = 100)
+
+# Run progress: 20.83% complete, ETA 00:11:22
+# Fork: 1 of 1
+# Warmup Iteration   1: 5644.085 ns/op
+# Warmup Iteration   2: 6865.070 ns/op
+# Warmup Iteration   3: 7140.847 ns/op
+# Warmup Iteration   4: 14433.159 ns/op
+# Warmup Iteration   5: 11695.972 ns/op
+Iteration   1: 12080.413 ns/op
+Iteration   2: 8348.493 ns/op
+Iteration   3: 9553.310 ns/op
+Iteration   4: 11269.227 ns/op
+Iteration   5: 9593.082 ns/op
+
+
+Result "org.example.Main.yieldAfterEachCall":
+10168.905 ±(99.9%) 5740.237 ns/op [Average]
+(min, avg, max) = (8348.493, 10168.905, 12080.413), stdev = 1490.721
+CI (99.9%): [4428.668, 15909.142] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldAfterEachCall
+# Parameters: (paramCount = 2, stackDepth = 5)
+
+# Run progress: 22.22% complete, ETA 00:11:06
+# Fork: 1 of 1
+# Warmup Iteration   1: 1336.731 ns/op
+# Warmup Iteration   2: 1062.082 ns/op
+# Warmup Iteration   3: 916.589 ns/op
+# Warmup Iteration   4: 800.469 ns/op
+# Warmup Iteration   5: 756.224 ns/op
+Iteration   1: 712.056 ns/op
+Iteration   2: 787.093 ns/op
+Iteration   3: 772.519 ns/op
+Iteration   4: 634.973 ns/op
+Iteration   5: 659.886 ns/op
+
+
+Result "org.example.Main.yieldAfterEachCall":
+713.305 ±(99.9%) 257.892 ns/op [Average]
+(min, avg, max) = (634.973, 713.305, 787.093), stdev = 66.974
+CI (99.9%): [455.413, 971.198] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldAfterEachCall
+# Parameters: (paramCount = 2, stackDepth = 10)
+
+# Run progress: 23.61% complete, ETA 00:10:52
+# Fork: 1 of 1
+# Warmup Iteration   1: 1004.391 ns/op
+# Warmup Iteration   2: 977.545 ns/op
+# Warmup Iteration   3: 1219.406 ns/op
+# Warmup Iteration   4: 1048.695 ns/op
+# Warmup Iteration   5: 1046.038 ns/op
+Iteration   1: 1070.644 ns/op
+Iteration   2: 1131.666 ns/op
+Iteration   3: 838.428 ns/op
+Iteration   4: 769.363 ns/op
+Iteration   5: 755.371 ns/op
+
+
+Result "org.example.Main.yieldAfterEachCall":
+913.095 ±(99.9%) 677.172 ns/op [Average]
+(min, avg, max) = (755.371, 913.095, 1131.666), stdev = 175.859
+CI (99.9%): [235.923, 1590.266] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldAfterEachCall
+# Parameters: (paramCount = 2, stackDepth = 20)
+
+# Run progress: 25.00% complete, ETA 00:10:37
+# Fork: 1 of 1
+# Warmup Iteration   1: 1523.154 ns/op
+# Warmup Iteration   2: 1450.816 ns/op
+# Warmup Iteration   3: 1537.501 ns/op
+# Warmup Iteration   4: 1637.880 ns/op
+# Warmup Iteration   5: 1407.252 ns/op
+Iteration   1: 1589.134 ns/op
+Iteration   2: 1418.041 ns/op
+Iteration   3: 1535.185 ns/op
+Iteration   4: 1657.218 ns/op
+Iteration   5: 1650.350 ns/op
+
+
+Result "org.example.Main.yieldAfterEachCall":
+1569.985 ±(99.9%) 378.916 ns/op [Average]
+(min, avg, max) = (1418.041, 1569.985, 1657.218), stdev = 98.403
+CI (99.9%): [1191.069, 1948.902] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldAfterEachCall
+# Parameters: (paramCount = 2, stackDepth = 100)
+
+# Run progress: 26.39% complete, ETA 00:10:22
+# Fork: 1 of 1
+# Warmup Iteration   1: 6372.784 ns/op
+# Warmup Iteration   2: 7012.509 ns/op
+# Warmup Iteration   3: 6317.887 ns/op
+# Warmup Iteration   4: 6172.457 ns/op
+# Warmup Iteration   5: 5957.616 ns/op
+Iteration   1: 5803.894 ns/op
+Iteration   2: 5824.720 ns/op
+Iteration   3: 5802.405 ns/op
+Iteration   4: 5617.204 ns/op
+Iteration   5: 5668.814 ns/op
+
+
+Result "org.example.Main.yieldAfterEachCall":
+5743.407 ±(99.9%) 361.441 ns/op [Average]
+(min, avg, max) = (5617.204, 5743.407, 5824.720), stdev = 93.865
+CI (99.9%): [5381.967, 6104.848] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldAfterEachCall
+# Parameters: (paramCount = 3, stackDepth = 5)
+
+# Run progress: 27.78% complete, ETA 00:10:08
+# Fork: 1 of 1
+# Warmup Iteration   1: 569.290 ns/op
+# Warmup Iteration   2: 591.466 ns/op
+# Warmup Iteration   3: 612.235 ns/op
+# Warmup Iteration   4: 676.403 ns/op
+# Warmup Iteration   5: 624.171 ns/op
+Iteration   1: 603.713 ns/op
+Iteration   2: 582.582 ns/op
+Iteration   3: 611.370 ns/op
+Iteration   4: 649.902 ns/op
+Iteration   5: 653.649 ns/op
+
+
+Result "org.example.Main.yieldAfterEachCall":
+620.244 ±(99.9%) 118.152 ns/op [Average]
+(min, avg, max) = (582.582, 620.244, 653.649), stdev = 30.684
+CI (99.9%): [502.092, 738.396] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldAfterEachCall
+# Parameters: (paramCount = 3, stackDepth = 10)
+
+# Run progress: 29.17% complete, ETA 00:09:54
+# Fork: 1 of 1
+# Warmup Iteration   1: 1090.444 ns/op
+# Warmup Iteration   2: 888.971 ns/op
+# Warmup Iteration   3: 880.315 ns/op
+# Warmup Iteration   4: 1019.478 ns/op
+# Warmup Iteration   5: 911.529 ns/op
+Iteration   1: 974.493 ns/op
+Iteration   2: 884.852 ns/op
+Iteration   3: 897.854 ns/op
+Iteration   4: 898.151 ns/op
+Iteration   5: 1020.851 ns/op
+
+
+Result "org.example.Main.yieldAfterEachCall":
+935.240 ±(99.9%) 229.286 ns/op [Average]
+(min, avg, max) = (884.852, 935.240, 1020.851), stdev = 59.545
+CI (99.9%): [705.954, 1164.526] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldAfterEachCall
+# Parameters: (paramCount = 3, stackDepth = 20)
+
+# Run progress: 30.56% complete, ETA 00:09:40
+# Fork: 1 of 1
+# Warmup Iteration   1: 1756.561 ns/op
+# Warmup Iteration   2: 1693.711 ns/op
+# Warmup Iteration   3: 1691.266 ns/op
+# Warmup Iteration   4: 1989.625 ns/op
+# Warmup Iteration   5: 1632.741 ns/op
+Iteration   1: 1560.768 ns/op
+Iteration   2: 1450.503 ns/op
+Iteration   3: 1420.542 ns/op
+Iteration   4: 1413.409 ns/op
+Iteration   5: 1330.154 ns/op
+
+
+Result "org.example.Main.yieldAfterEachCall":
+1435.075 ±(99.9%) 320.586 ns/op [Average]
+(min, avg, max) = (1330.154, 1435.075, 1560.768), stdev = 83.255
+CI (99.9%): [1114.489, 1755.661] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldAfterEachCall
+# Parameters: (paramCount = 3, stackDepth = 100)
+
+# Run progress: 31.94% complete, ETA 00:09:27
+# Fork: 1 of 1
+# Warmup Iteration   1: 6185.986 ns/op
+# Warmup Iteration   2: 5828.171 ns/op
+# Warmup Iteration   3: 5636.130 ns/op
+# Warmup Iteration   4: 5817.526 ns/op
+# Warmup Iteration   5: 6580.334 ns/op
+Iteration   1: 6824.924 ns/op
+Iteration   2: 6994.814 ns/op
+Iteration   3: 7362.890 ns/op
+Iteration   4: 6888.634 ns/op
+Iteration   5: 6949.740 ns/op
+
+
+Result "org.example.Main.yieldAfterEachCall":
+7004.200 ±(99.9%) 810.484 ns/op [Average]
+(min, avg, max) = (6824.924, 7004.200, 7362.890), stdev = 210.480
+CI (99.9%): [6193.716, 7814.685] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeAndAfterEachCall
+# Parameters: (paramCount = 1, stackDepth = 5)
+
+# Run progress: 33.33% complete, ETA 00:09:13
+# Fork: 1 of 1
+# Warmup Iteration   1: 1010.795 ns/op
+# Warmup Iteration   2: 987.031 ns/op
+# Warmup Iteration   3: 893.874 ns/op
+# Warmup Iteration   4: 948.844 ns/op
+# Warmup Iteration   5: 812.744 ns/op
+Iteration   1: 794.795 ns/op
+Iteration   2: 777.321 ns/op
+Iteration   3: 783.744 ns/op
+Iteration   4: 844.252 ns/op
+Iteration   5: 839.167 ns/op
+
+
+Result "org.example.Main.yieldBeforeAndAfterEachCall":
+807.856 ±(99.9%) 121.607 ns/op [Average]
+(min, avg, max) = (777.321, 807.856, 844.252), stdev = 31.581
+CI (99.9%): [686.249, 929.463] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeAndAfterEachCall
+# Parameters: (paramCount = 1, stackDepth = 10)
+
+# Run progress: 34.72% complete, ETA 00:09:00
+# Fork: 1 of 1
+# Warmup Iteration   1: 1806.057 ns/op
+# Warmup Iteration   2: 1624.312 ns/op
+# Warmup Iteration   3: 1627.058 ns/op
+# Warmup Iteration   4: 1617.862 ns/op
+# Warmup Iteration   5: 1683.155 ns/op
+Iteration   1: 1594.771 ns/op
+Iteration   2: 1575.955 ns/op
+Iteration   3: 1469.471 ns/op
+Iteration   4: 1607.880 ns/op
+Iteration   5: 1671.463 ns/op
+
+
+Result "org.example.Main.yieldBeforeAndAfterEachCall":
+1583.908 ±(99.9%) 282.423 ns/op [Average]
+(min, avg, max) = (1469.471, 1583.908, 1671.463), stdev = 73.344
+CI (99.9%): [1301.485, 1866.331] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeAndAfterEachCall
+# Parameters: (paramCount = 1, stackDepth = 20)
+
+# Run progress: 36.11% complete, ETA 00:08:48
+# Fork: 1 of 1
+# Warmup Iteration   1: 2936.806 ns/op
+# Warmup Iteration   2: 3049.227 ns/op
+# Warmup Iteration   3: 2666.360 ns/op
+# Warmup Iteration   4: 2732.014 ns/op
+# Warmup Iteration   5: 2978.894 ns/op
+Iteration   1: 2997.082 ns/op
+Iteration   2: 2965.451 ns/op
+Iteration   3: 2961.238 ns/op
+Iteration   4: 2860.091 ns/op
+Iteration   5: 3010.246 ns/op
+
+
+Result "org.example.Main.yieldBeforeAndAfterEachCall":
+2958.822 ±(99.9%) 227.041 ns/op [Average]
+(min, avg, max) = (2860.091, 2958.822, 3010.246), stdev = 58.962
+CI (99.9%): [2731.781, 3185.863] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeAndAfterEachCall
+# Parameters: (paramCount = 1, stackDepth = 100)
+
+# Run progress: 37.50% complete, ETA 00:08:35
+# Fork: 1 of 1
+# Warmup Iteration   1: 13965.233 ns/op
+# Warmup Iteration   2: 13195.020 ns/op
+# Warmup Iteration   3: 12647.102 ns/op
+# Warmup Iteration   4: 10994.448 ns/op
+# Warmup Iteration   5: 11089.592 ns/op
+Iteration   1: 11061.343 ns/op
+Iteration   2: 11031.642 ns/op
+Iteration   3: 12242.543 ns/op
+Iteration   4: 11320.684 ns/op
+Iteration   5: 13951.956 ns/op
+
+
+Result "org.example.Main.yieldBeforeAndAfterEachCall":
+11921.634 ±(99.9%) 4762.406 ns/op [Average]
+(min, avg, max) = (11031.642, 11921.634, 13951.956), stdev = 1236.782
+CI (99.9%): [7159.227, 16684.040] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeAndAfterEachCall
+# Parameters: (paramCount = 2, stackDepth = 5)
+
+# Run progress: 38.89% complete, ETA 00:08:23
+# Fork: 1 of 1
+# Warmup Iteration   1: 884.708 ns/op
+# Warmup Iteration   2: 896.398 ns/op
+# Warmup Iteration   3: 1022.238 ns/op
+# Warmup Iteration   4: 1047.437 ns/op
+# Warmup Iteration   5: 1007.495 ns/op
+Iteration   1: 1036.720 ns/op
+Iteration   2: 1091.554 ns/op
+Iteration   3: 1024.754 ns/op
+Iteration   4: 1028.027 ns/op
+Iteration   5: 927.197 ns/op
+
+
+Result "org.example.Main.yieldBeforeAndAfterEachCall":
+1021.651 ±(99.9%) 228.500 ns/op [Average]
+(min, avg, max) = (927.197, 1021.651, 1091.554), stdev = 59.341
+CI (99.9%): [793.150, 1250.151] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeAndAfterEachCall
+# Parameters: (paramCount = 2, stackDepth = 10)
+
+# Run progress: 40.28% complete, ETA 00:08:10
+# Fork: 1 of 1
+# Warmup Iteration   1: 1655.177 ns/op
+# Warmup Iteration   2: 1529.697 ns/op
+# Warmup Iteration   3: 1831.483 ns/op
+# Warmup Iteration   4: 1754.379 ns/op
+# Warmup Iteration   5: 1482.088 ns/op
+Iteration   1: 1539.335 ns/op
+Iteration   2: 1696.431 ns/op
+Iteration   3: 1674.841 ns/op
+Iteration   4: 1641.414 ns/op
+Iteration   5: 1805.616 ns/op
+
+
+Result "org.example.Main.yieldBeforeAndAfterEachCall":
+1671.527 ±(99.9%) 370.307 ns/op [Average]
+(min, avg, max) = (1539.335, 1671.527, 1805.616), stdev = 96.167
+CI (99.9%): [1301.221, 2041.834] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeAndAfterEachCall
+# Parameters: (paramCount = 2, stackDepth = 20)
+
+# Run progress: 41.67% complete, ETA 00:07:58
+# Fork: 1 of 1
+# Warmup Iteration   1: 3443.128 ns/op
+# Warmup Iteration   2: 3122.058 ns/op
+# Warmup Iteration   3: 3063.842 ns/op
+# Warmup Iteration   4: 3262.012 ns/op
+# Warmup Iteration   5: 2837.675 ns/op
+Iteration   1: 3035.674 ns/op
+Iteration   2: 2700.477 ns/op
+Iteration   3: 2736.756 ns/op
+Iteration   4: 3235.784 ns/op
+Iteration   5: 2493.629 ns/op
+
+
+Result "org.example.Main.yieldBeforeAndAfterEachCall":
+2840.464 ±(99.9%) 1130.921 ns/op [Average]
+(min, avg, max) = (2493.629, 2840.464, 3235.784), stdev = 293.697
+CI (99.9%): [1709.542, 3971.385] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeAndAfterEachCall
+# Parameters: (paramCount = 2, stackDepth = 100)
+
+# Run progress: 43.06% complete, ETA 00:07:46
+# Fork: 1 of 1
+# Warmup Iteration   1: 12995.786 ns/op
+# Warmup Iteration   2: 15695.994 ns/op
+# Warmup Iteration   3: 16779.191 ns/op
+# Warmup Iteration   4: 15099.435 ns/op
+# Warmup Iteration   5: 16083.474 ns/op
+Iteration   1: 15526.512 ns/op
+Iteration   2: 14942.730 ns/op
+Iteration   3: 14155.919 ns/op
+Iteration   4: 14708.151 ns/op
+Iteration   5: 15009.091 ns/op
+
+
+Result "org.example.Main.yieldBeforeAndAfterEachCall":
+14868.481 ±(99.9%) 1917.354 ns/op [Average]
+(min, avg, max) = (14155.919, 14868.481, 15526.512), stdev = 497.931
+CI (99.9%): [12951.127, 16785.834] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeAndAfterEachCall
+# Parameters: (paramCount = 3, stackDepth = 5)
+
+# Run progress: 44.44% complete, ETA 00:07:34
+# Fork: 1 of 1
+# Warmup Iteration   1: 1179.478 ns/op
+# Warmup Iteration   2: 1561.914 ns/op
+# Warmup Iteration   3: 1797.293 ns/op
+# Warmup Iteration   4: 1556.023 ns/op
+# Warmup Iteration   5: 1508.666 ns/op
+Iteration   1: 1323.190 ns/op
+Iteration   2: 1546.368 ns/op
+Iteration   3: 1179.027 ns/op
+Iteration   4: 1588.315 ns/op
+Iteration   5: 1481.848 ns/op
+
+
+Result "org.example.Main.yieldBeforeAndAfterEachCall":
+1423.749 ±(99.9%) 654.309 ns/op [Average]
+(min, avg, max) = (1179.027, 1423.749, 1588.315), stdev = 169.922
+CI (99.9%): [769.441, 2078.058] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeAndAfterEachCall
+# Parameters: (paramCount = 3, stackDepth = 10)
+
+# Run progress: 45.83% complete, ETA 00:07:22
+# Fork: 1 of 1
+# Warmup Iteration   1: 2342.973 ns/op
+# Warmup Iteration   2: 1932.536 ns/op
+# Warmup Iteration   3: 2292.481 ns/op
+# Warmup Iteration   4: 2145.196 ns/op
+# Warmup Iteration   5: 2510.081 ns/op
+Iteration   1: 2184.727 ns/op
+Iteration   2: 2505.229 ns/op
+Iteration   3: 1901.743 ns/op
+Iteration   4: 1949.940 ns/op
+Iteration   5: 1854.783 ns/op
+
+
+Result "org.example.Main.yieldBeforeAndAfterEachCall":
+2079.284 ±(99.9%) 1038.959 ns/op [Average]
+(min, avg, max) = (1854.783, 2079.284, 2505.229), stdev = 269.814
+CI (99.9%): [1040.325, 3118.243] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeAndAfterEachCall
+# Parameters: (paramCount = 3, stackDepth = 20)
+
+# Run progress: 47.22% complete, ETA 00:07:11
+# Fork: 1 of 1
+# Warmup Iteration   1: 3275.248 ns/op
+# Warmup Iteration   2: 3020.969 ns/op
+# Warmup Iteration   3: 3229.707 ns/op
+# Warmup Iteration   4: 3327.610 ns/op
+# Warmup Iteration   5: 3856.469 ns/op
+Iteration   1: 3548.129 ns/op
+Iteration   2: 3925.610 ns/op
+Iteration   3: 5905.283 ns/op
+Iteration   4: 5802.602 ns/op
+Iteration   5: 5822.782 ns/op
+
+
+Result "org.example.Main.yieldBeforeAndAfterEachCall":
+5000.881 ±(99.9%) 4475.254 ns/op [Average]
+(min, avg, max) = (3548.129, 5000.881, 5905.283), stdev = 1162.209
+CI (99.9%): [525.627, 9476.135] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeAndAfterEachCall
+# Parameters: (paramCount = 3, stackDepth = 100)
+
+# Run progress: 48.61% complete, ETA 00:06:59
+# Fork: 1 of 1
+# Warmup Iteration   1: 29298.905 ns/op
+# Warmup Iteration   2: 26679.515 ns/op
+# Warmup Iteration   3: 26010.442 ns/op
+# Warmup Iteration   4: 24155.924 ns/op
+# Warmup Iteration   5: 19930.902 ns/op
+Iteration   1: 26662.047 ns/op
+Iteration   2: 22758.937 ns/op
+Iteration   3: 20172.393 ns/op
+Iteration   4: 20194.982 ns/op
+Iteration   5: 15412.556 ns/op
+
+
+Result "org.example.Main.yieldBeforeAndAfterEachCall":
+21040.183 ±(99.9%) 15841.209 ns/op [Average]
+(min, avg, max) = (15412.556, 21040.183, 26662.047), stdev = 4113.912
+CI (99.9%): [5198.973, 36881.392] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeEachCall
+# Parameters: (paramCount = 1, stackDepth = 5)
+
+# Run progress: 50.00% complete, ETA 00:06:48
+# Fork: 1 of 1
+# Warmup Iteration   1: 871.219 ns/op
+# Warmup Iteration   2: 753.475 ns/op
+# Warmup Iteration   3: 857.250 ns/op
+# Warmup Iteration   4: 1075.866 ns/op
+# Warmup Iteration   5: 860.296 ns/op
+Iteration   1: 909.786 ns/op
+Iteration   2: 1058.727 ns/op
+Iteration   3: 908.784 ns/op
+Iteration   4: 1127.870 ns/op
+Iteration   5: 968.227 ns/op
+
+
+Result "org.example.Main.yieldBeforeEachCall":
+994.679 ±(99.9%) 370.974 ns/op [Average]
+(min, avg, max) = (908.784, 994.679, 1127.870), stdev = 96.341
+CI (99.9%): [623.704, 1365.653] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeEachCall
+# Parameters: (paramCount = 1, stackDepth = 10)
+
+# Run progress: 51.39% complete, ETA 00:06:36
+# Fork: 1 of 1
+# Warmup Iteration   1: 1368.091 ns/op
+# Warmup Iteration   2: 1310.523 ns/op
+# Warmup Iteration   3: 1093.563 ns/op
+# Warmup Iteration   4: 1220.751 ns/op
+# Warmup Iteration   5: 1395.389 ns/op
+Iteration   1: 1215.711 ns/op
+Iteration   2: 1316.811 ns/op
+Iteration   3: 1278.257 ns/op
+Iteration   4: 1097.649 ns/op
+Iteration   5: 1375.262 ns/op
+
+
+Result "org.example.Main.yieldBeforeEachCall":
+1256.738 ±(99.9%) 408.932 ns/op [Average]
+(min, avg, max) = (1097.649, 1256.738, 1375.262), stdev = 106.198
+CI (99.9%): [847.807, 1665.670] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeEachCall
+# Parameters: (paramCount = 1, stackDepth = 20)
+
+# Run progress: 52.78% complete, ETA 00:06:24
+# Fork: 1 of 1
+# Warmup Iteration   1: 2165.857 ns/op
+# Warmup Iteration   2: 2150.582 ns/op
+# Warmup Iteration   3: 2187.621 ns/op
+# Warmup Iteration   4: 2194.902 ns/op
+# Warmup Iteration   5: 2370.311 ns/op
+Iteration   1: 2313.828 ns/op
+Iteration   2: 2253.636 ns/op
+Iteration   3: 2242.515 ns/op
+Iteration   4: 2061.842 ns/op
+Iteration   5: 2098.325 ns/op
+
+
+Result "org.example.Main.yieldBeforeEachCall":
+2194.029 ±(99.9%) 416.903 ns/op [Average]
+(min, avg, max) = (2061.842, 2194.029, 2313.828), stdev = 108.269
+CI (99.9%): [1777.126, 2610.933] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeEachCall
+# Parameters: (paramCount = 1, stackDepth = 100)
+
+# Run progress: 54.17% complete, ETA 00:06:13
+# Fork: 1 of 1
+# Warmup Iteration   1: 8654.671 ns/op
+# Warmup Iteration   2: 8521.128 ns/op
+# Warmup Iteration   3: 8564.042 ns/op
+# Warmup Iteration   4: 9212.129 ns/op
+# Warmup Iteration   5: 8152.309 ns/op
+Iteration   1: 7431.377 ns/op
+Iteration   2: 7681.836 ns/op
+Iteration   3: 9423.074 ns/op
+Iteration   4: 9867.152 ns/op
+Iteration   5: 9191.565 ns/op
+
+
+Result "org.example.Main.yieldBeforeEachCall":
+8719.001 ±(99.9%) 4205.396 ns/op [Average]
+(min, avg, max) = (7431.377, 8719.001, 9867.152), stdev = 1092.128
+CI (99.9%): [4513.605, 12924.397] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeEachCall
+# Parameters: (paramCount = 2, stackDepth = 5)
+
+# Run progress: 55.56% complete, ETA 00:06:01
+# Fork: 1 of 1
+# Warmup Iteration   1: 1002.813 ns/op
+# Warmup Iteration   2: 922.116 ns/op
+# Warmup Iteration   3: 917.397 ns/op
+# Warmup Iteration   4: 961.947 ns/op
+# Warmup Iteration   5: 829.304 ns/op
+Iteration   1: 801.669 ns/op
+Iteration   2: 871.275 ns/op
+Iteration   3: 796.732 ns/op
+Iteration   4: 806.329 ns/op
+Iteration   5: 779.547 ns/op
+
+
+Result "org.example.Main.yieldBeforeEachCall":
+811.110 ±(99.9%) 135.250 ns/op [Average]
+(min, avg, max) = (779.547, 811.110, 871.275), stdev = 35.124
+CI (99.9%): [675.861, 946.360] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeEachCall
+# Parameters: (paramCount = 2, stackDepth = 10)
+
+# Run progress: 56.94% complete, ETA 00:05:50
+# Fork: 1 of 1
+# Warmup Iteration   1: 1373.752 ns/op
+# Warmup Iteration   2: 1246.082 ns/op
+# Warmup Iteration   3: 1439.819 ns/op
+# Warmup Iteration   4: 1388.857 ns/op
+# Warmup Iteration   5: 1415.525 ns/op
+Iteration   1: 1543.637 ns/op
+Iteration   2: 1500.716 ns/op
+Iteration   3: 1474.244 ns/op
+Iteration   4: 1381.965 ns/op
+Iteration   5: 1362.502 ns/op
+
+
+Result "org.example.Main.yieldBeforeEachCall":
+1452.613 ±(99.9%) 299.375 ns/op [Average]
+(min, avg, max) = (1362.502, 1452.613, 1543.637), stdev = 77.747
+CI (99.9%): [1153.238, 1751.988] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeEachCall
+# Parameters: (paramCount = 2, stackDepth = 20)
+
+# Run progress: 58.33% complete, ETA 00:05:38
+# Fork: 1 of 1
+# Warmup Iteration   1: 2491.263 ns/op
+# Warmup Iteration   2: 2285.167 ns/op
+# Warmup Iteration   3: 2240.437 ns/op
+# Warmup Iteration   4: 2075.695 ns/op
+# Warmup Iteration   5: 2031.838 ns/op
+Iteration   1: 2065.039 ns/op
+Iteration   2: 2090.413 ns/op
+Iteration   3: 2123.697 ns/op
+Iteration   4: 2014.212 ns/op
+Iteration   5: 2429.141 ns/op
+
+
+Result "org.example.Main.yieldBeforeEachCall":
+2144.500 ±(99.9%) 631.751 ns/op [Average]
+(min, avg, max) = (2014.212, 2144.500, 2429.141), stdev = 164.064
+CI (99.9%): [1512.749, 2776.251] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeEachCall
+# Parameters: (paramCount = 2, stackDepth = 100)
+
+# Run progress: 59.72% complete, ETA 00:05:27
+# Fork: 1 of 1
+# Warmup Iteration   1: 11971.201 ns/op
+# Warmup Iteration   2: 10993.176 ns/op
+# Warmup Iteration   3: 11187.765 ns/op
+# Warmup Iteration   4: 11080.762 ns/op
+# Warmup Iteration   5: 10990.612 ns/op
+Iteration   1: 10479.999 ns/op
+Iteration   2: 9330.774 ns/op
+Iteration   3: 9460.457 ns/op
+Iteration   4: 9941.053 ns/op
+Iteration   5: 10184.595 ns/op
+
+
+Result "org.example.Main.yieldBeforeEachCall":
+9879.375 ±(99.9%) 1860.870 ns/op [Average]
+(min, avg, max) = (9330.774, 9879.375, 10479.999), stdev = 483.262
+CI (99.9%): [8018.505, 11740.246] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeEachCall
+# Parameters: (paramCount = 3, stackDepth = 5)
+
+# Run progress: 61.11% complete, ETA 00:05:15
+# Fork: 1 of 1
+# Warmup Iteration   1: 1112.109 ns/op
+# Warmup Iteration   2: 923.106 ns/op
+# Warmup Iteration   3: 935.415 ns/op
+# Warmup Iteration   4: 1047.460 ns/op
+# Warmup Iteration   5: 1007.692 ns/op
+Iteration   1: 1050.256 ns/op
+Iteration   2: 1114.873 ns/op
+Iteration   3: 1011.748 ns/op
+Iteration   4: 969.292 ns/op
+Iteration   5: 1039.437 ns/op
+
+
+Result "org.example.Main.yieldBeforeEachCall":
+1037.121 ±(99.9%) 206.179 ns/op [Average]
+(min, avg, max) = (969.292, 1037.121, 1114.873), stdev = 53.544
+CI (99.9%): [830.943, 1243.300] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeEachCall
+# Parameters: (paramCount = 3, stackDepth = 10)
+
+# Run progress: 62.50% complete, ETA 00:05:04
+# Fork: 1 of 1
+# Warmup Iteration   1: 1800.486 ns/op
+# Warmup Iteration   2: 1470.783 ns/op
+# Warmup Iteration   3: 1442.799 ns/op
+# Warmup Iteration   4: 1350.661 ns/op
+# Warmup Iteration   5: 1340.713 ns/op
+Iteration   1: 1592.237 ns/op
+Iteration   2: 1275.461 ns/op
+Iteration   3: 1520.587 ns/op
+Iteration   4: 1387.631 ns/op
+Iteration   5: 1397.483 ns/op
+
+
+Result "org.example.Main.yieldBeforeEachCall":
+1434.680 ±(99.9%) 476.111 ns/op [Average]
+(min, avg, max) = (1275.461, 1434.680, 1592.237), stdev = 123.645
+CI (99.9%): [958.569, 1910.791] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeEachCall
+# Parameters: (paramCount = 3, stackDepth = 20)
+
+# Run progress: 63.89% complete, ETA 00:04:53
+# Fork: 1 of 1
+# Warmup Iteration   1: 2930.983 ns/op
+# Warmup Iteration   2: 2766.728 ns/op
+# Warmup Iteration   3: 2783.925 ns/op
+# Warmup Iteration   4: 2824.886 ns/op
+# Warmup Iteration   5: 2857.662 ns/op
+Iteration   1: 2796.542 ns/op
+Iteration   2: 2756.401 ns/op
+Iteration   3: 2674.116 ns/op
+Iteration   4: 2737.345 ns/op
+Iteration   5: 2809.197 ns/op
+
+
+Result "org.example.Main.yieldBeforeEachCall":
+2754.720 ±(99.9%) 206.634 ns/op [Average]
+(min, avg, max) = (2674.116, 2754.720, 2809.197), stdev = 53.662
+CI (99.9%): [2548.086, 2961.354] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldBeforeEachCall
+# Parameters: (paramCount = 3, stackDepth = 100)
+
+# Run progress: 65.28% complete, ETA 00:04:41
+# Fork: 1 of 1
+# Warmup Iteration   1: 12120.521 ns/op
+# Warmup Iteration   2: 9911.625 ns/op
+# Warmup Iteration   3: 10670.975 ns/op
+# Warmup Iteration   4: 10482.180 ns/op
+# Warmup Iteration   5: 9677.067 ns/op
+Iteration   1: 10721.262 ns/op
+Iteration   2: 12646.690 ns/op
+Iteration   3: 11129.388 ns/op
+Iteration   4: 11293.508 ns/op
+Iteration   5: 11702.444 ns/op
+
+
+Result "org.example.Main.yieldBeforeEachCall":
+11498.658 ±(99.9%) 2818.016 ns/op [Average]
+(min, avg, max) = (10721.262, 11498.658, 12646.690), stdev = 731.830
+CI (99.9%): [8680.642, 14316.675] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldThenContinue
+# Parameters: (paramCount = 1, stackDepth = 5)
+
+# Run progress: 66.67% complete, ETA 00:04:30
+# Fork: 1 of 1
+# Warmup Iteration   1: 722.352 ns/op
+# Warmup Iteration   2: 747.007 ns/op
+# Warmup Iteration   3: 598.294 ns/op
+# Warmup Iteration   4: 710.445 ns/op
+# Warmup Iteration   5: 608.995 ns/op
+Iteration   1: 679.074 ns/op
+Iteration   2: 671.341 ns/op
+Iteration   3: 613.473 ns/op
+Iteration   4: 631.492 ns/op
+Iteration   5: 654.861 ns/op
+
+
+Result "org.example.Main.yieldThenContinue":
+650.048 ±(99.9%) 105.474 ns/op [Average]
+(min, avg, max) = (613.473, 650.048, 679.074), stdev = 27.391
+CI (99.9%): [544.575, 755.522] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldThenContinue
+# Parameters: (paramCount = 1, stackDepth = 10)
+
+# Run progress: 68.06% complete, ETA 00:04:19
+# Fork: 1 of 1
+# Warmup Iteration   1: 726.353 ns/op
+# Warmup Iteration   2: 855.304 ns/op
+# Warmup Iteration   3: 920.592 ns/op
+# Warmup Iteration   4: 812.069 ns/op
+# Warmup Iteration   5: 768.236 ns/op
+Iteration   1: 706.274 ns/op
+Iteration   2: 785.754 ns/op
+Iteration   3: 847.001 ns/op
+Iteration   4: 757.905 ns/op
+Iteration   5: 777.479 ns/op
+
+
+Result "org.example.Main.yieldThenContinue":
+774.883 ±(99.9%) 195.603 ns/op [Average]
+(min, avg, max) = (706.274, 774.883, 847.001), stdev = 50.797
+CI (99.9%): [579.280, 970.485] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldThenContinue
+# Parameters: (paramCount = 1, stackDepth = 20)
+
+# Run progress: 69.44% complete, ETA 00:04:07
+# Fork: 1 of 1
+# Warmup Iteration   1: 833.484 ns/op
+# Warmup Iteration   2: 752.580 ns/op
+# Warmup Iteration   3: 814.517 ns/op
+# Warmup Iteration   4: 734.869 ns/op
+# Warmup Iteration   5: 688.493 ns/op
+Iteration   1: 727.445 ns/op
+Iteration   2: 754.015 ns/op
+Iteration   3: 833.197 ns/op
+Iteration   4: 799.291 ns/op
+Iteration   5: 777.048 ns/op
+
+
+Result "org.example.Main.yieldThenContinue":
+778.199 ±(99.9%) 156.791 ns/op [Average]
+(min, avg, max) = (727.445, 778.199, 833.197), stdev = 40.718
+CI (99.9%): [621.409, 934.990] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldThenContinue
+# Parameters: (paramCount = 1, stackDepth = 100)
+
+# Run progress: 70.83% complete, ETA 00:03:56
+# Fork: 1 of 1
+# Warmup Iteration   1: 2038.671 ns/op
+# Warmup Iteration   2: 1934.078 ns/op
+# Warmup Iteration   3: 1835.611 ns/op
+# Warmup Iteration   4: 1849.670 ns/op
+# Warmup Iteration   5: 1673.457 ns/op
+Iteration   1: 1707.099 ns/op
+Iteration   2: 1546.457 ns/op
+Iteration   3: 1656.794 ns/op
+Iteration   4: 1551.555 ns/op
+Iteration   5: 1860.327 ns/op
+
+
+Result "org.example.Main.yieldThenContinue":
+1664.446 ±(99.9%) 498.033 ns/op [Average]
+(min, avg, max) = (1546.457, 1664.446, 1860.327), stdev = 129.338
+CI (99.9%): [1166.413, 2162.480] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldThenContinue
+# Parameters: (paramCount = 2, stackDepth = 5)
+
+# Run progress: 72.22% complete, ETA 00:03:45
+# Fork: 1 of 1
+# Warmup Iteration   1: 909.467 ns/op
+# Warmup Iteration   2: 816.575 ns/op
+# Warmup Iteration   3: 949.987 ns/op
+# Warmup Iteration   4: 917.979 ns/op
+# Warmup Iteration   5: 878.048 ns/op
+Iteration   1: 880.781 ns/op
+Iteration   2: 993.124 ns/op
+Iteration   3: 867.912 ns/op
+Iteration   4: 856.956 ns/op
+Iteration   5: 810.910 ns/op
+
+
+Result "org.example.Main.yieldThenContinue":
+881.937 ±(99.9%) 259.950 ns/op [Average]
+(min, avg, max) = (810.910, 881.937, 993.124), stdev = 67.508
+CI (99.9%): [621.987, 1141.886] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldThenContinue
+# Parameters: (paramCount = 2, stackDepth = 10)
+
+# Run progress: 73.61% complete, ETA 00:03:34
+# Fork: 1 of 1
+# Warmup Iteration   1: 1028.917 ns/op
+# Warmup Iteration   2: 1287.090 ns/op
+# Warmup Iteration   3: 1176.009 ns/op
+# Warmup Iteration   4: 1049.623 ns/op
+# Warmup Iteration   5: 1113.078 ns/op
+Iteration   1: 987.013 ns/op
+Iteration   2: 1040.052 ns/op
+Iteration   3: 1134.056 ns/op
+Iteration   4: 1227.590 ns/op
+Iteration   5: 2492.938 ns/op
+
+
+Result "org.example.Main.yieldThenContinue":
+1376.330 ±(99.9%) 2429.481 ns/op [Average]
+(min, avg, max) = (987.013, 1376.330, 2492.938), stdev = 630.929
+CI (99.9%): [≈ 0, 3805.811] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldThenContinue
+# Parameters: (paramCount = 2, stackDepth = 20)
+
+# Run progress: 75.00% complete, ETA 00:03:22
+# Fork: 1 of 1
+# Warmup Iteration   1: 1940.509 ns/op
+# Warmup Iteration   2: 1575.187 ns/op
+# Warmup Iteration   3: 1468.888 ns/op
+# Warmup Iteration   4: 1488.617 ns/op
+# Warmup Iteration   5: 1411.808 ns/op
+Iteration   1: 1354.344 ns/op
+Iteration   2: 1183.966 ns/op
+Iteration   3: 1299.751 ns/op
+Iteration   4: 1201.748 ns/op
+Iteration   5: 1359.163 ns/op
+
+
+Result "org.example.Main.yieldThenContinue":
+1279.794 ±(99.9%) 319.451 ns/op [Average]
+(min, avg, max) = (1183.966, 1279.794, 1359.163), stdev = 82.960
+CI (99.9%): [960.343, 1599.246] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldThenContinue
+# Parameters: (paramCount = 2, stackDepth = 100)
+
+# Run progress: 76.39% complete, ETA 00:03:11
+# Fork: 1 of 1
+# Warmup Iteration   1: 3430.390 ns/op
+# Warmup Iteration   2: 3076.130 ns/op
+# Warmup Iteration   3: 3128.289 ns/op
+# Warmup Iteration   4: 3427.417 ns/op
+# Warmup Iteration   5: 4092.575 ns/op
+Iteration   1: 3544.373 ns/op
+Iteration   2: 3835.540 ns/op
+Iteration   3: 4308.673 ns/op
+Iteration   4: 4077.834 ns/op
+Iteration   5: 3462.942 ns/op
+
+
+Result "org.example.Main.yieldThenContinue":
+3845.872 ±(99.9%) 1369.059 ns/op [Average]
+(min, avg, max) = (3462.942, 3845.872, 4308.673), stdev = 355.540
+CI (99.9%): [2476.813, 5214.931] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldThenContinue
+# Parameters: (paramCount = 3, stackDepth = 5)
+
+# Run progress: 77.78% complete, ETA 00:03:00
+# Fork: 1 of 1
+# Warmup Iteration   1: 2406.527 ns/op
+# Warmup Iteration   2: 1860.555 ns/op
+# Warmup Iteration   3: 2633.564 ns/op
+# Warmup Iteration   4: 1090.225 ns/op
+# Warmup Iteration   5: 2808.367 ns/op
+Iteration   1: 2611.241 ns/op
+Iteration   2: 1173.561 ns/op
+Iteration   3: 1197.132 ns/op
+Iteration   4: 1089.848 ns/op
+Iteration   5: 1450.093 ns/op
+
+
+Result "org.example.Main.yieldThenContinue":
+1504.375 ±(99.9%) 2438.227 ns/op [Average]
+(min, avg, max) = (1089.848, 1504.375, 2611.241), stdev = 633.200
+CI (99.9%): [≈ 0, 3942.602] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldThenContinue
+# Parameters: (paramCount = 3, stackDepth = 10)
+
+# Run progress: 79.17% complete, ETA 00:02:49
+# Fork: 1 of 1
+# Warmup Iteration   1: 1988.871 ns/op
+# Warmup Iteration   2: 1627.154 ns/op
+# Warmup Iteration   3: 1642.667 ns/op
+# Warmup Iteration   4: 1520.714 ns/op
+# Warmup Iteration   5: 1664.324 ns/op
+Iteration   1: 1525.236 ns/op
+Iteration   2: 1391.629 ns/op
+Iteration   3: 1327.659 ns/op
+Iteration   4: 1493.031 ns/op
+Iteration   5: 1619.540 ns/op
+
+
+Result "org.example.Main.yieldThenContinue":
+1471.419 ±(99.9%) 440.460 ns/op [Average]
+(min, avg, max) = (1327.659, 1471.419, 1619.540), stdev = 114.386
+CI (99.9%): [1030.959, 1911.879] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldThenContinue
+# Parameters: (paramCount = 3, stackDepth = 20)
+
+# Run progress: 80.56% complete, ETA 00:02:38
+# Fork: 1 of 1
+# Warmup Iteration   1: 2060.187 ns/op
+# Warmup Iteration   2: 1846.737 ns/op
+# Warmup Iteration   3: 1804.748 ns/op
+# Warmup Iteration   4: 1841.626 ns/op
+# Warmup Iteration   5: 1848.094 ns/op
+Iteration   1: 2381.753 ns/op
+Iteration   2: 2655.596 ns/op
+Iteration   3: 2437.292 ns/op
+Iteration   4: 2238.912 ns/op
+Iteration   5: 2573.404 ns/op
+
+
+Result "org.example.Main.yieldThenContinue":
+2457.391 ±(99.9%) 628.618 ns/op [Average]
+(min, avg, max) = (2238.912, 2457.391, 2655.596), stdev = 163.250
+CI (99.9%): [1828.773, 3086.010] (assumes normal distribution)
+
+
+# JMH version: 1.23
+# VM version: JDK 1.8.0_362_fiber, OpenJDK 64-Bit Server VM, 25.362-b2
+# VM invoker: /home/jong/TencentKona-8.0.13-362-fiber/jre/bin/java
+# VM options: -Dfile.encoding=UTF-8
+# Warmup: 5 iterations, 1 s each
+# Measurement: 5 iterations, 1 s each
+# Timeout: 10 min per iteration
+# Threads: 1 thread, will synchronize iterations
+# Benchmark mode: Average time, time/op
+# Benchmark: org.example.Main.yieldThenContinue
+# Parameters: (paramCount = 3, stackDepth = 100)
+
+# Run progress: 81.94% complete, ETA 00:02:26
+# Fork: 1 of 1
+# Warmup Iteration   1: 12776.062 ns/op
+# Warmup Iteration   2: 7656.376 ns/op
+# Warmup Iteration   3: 8130.453 ns/op
+# Warmup Iteration   4: 6645.069 ns/op
+# Warmup Iteration   5: 6749.750 ns/op
+Iteration   1: 6472.049 ns/op
+Iteration   2: 6887.633 ns/op
+Iteration   3: 7158.105 ns/op
+Iteration   4: 7324.068 ns/op
+Iteration   5: 7679.940 ns/op
+
+
+Result "org.example.Main.yieldThenContinue":
+7104.359 ±(99.9%) 1753.250 ns/op [Average]
+(min, avg, max) = (6472.049, 7104.359, 7679.940), stdev = 455.313
+CI (99.9%): [5351.109, 8857.608] (assumes normal distribution)
+
+
+# Run complete. Total time: 00:11:19
+
+REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
+why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
+experiments, perform baseline and negative tests that provide experimental control, make sure
+the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
+Do not assume the numbers tell you what you want them to tell.
+
+Benchmark                         (paramCount)  (stackDepth)  Mode  Cnt      Score       Error  Units
+Main.noYield                                 1             5  avgt    5    467.495 ±   892.920  ns/op
+Main.noYield                                 1            10  avgt    5    223.979 ±    65.472  ns/op
+Main.noYield                                 1            20  avgt    5    251.242 ±    79.406  ns/op
+Main.noYield                                 1           100  avgt    5    590.648 ±    94.177  ns/op
+Main.noYield                                 2             5  avgt    5    263.731 ±    80.775  ns/op
+Main.noYield                                 2            10  avgt    5    342.560 ±    22.917  ns/op
+Main.noYield                                 2            20  avgt    5    428.286 ±   109.549  ns/op
+Main.noYield                                 2           100  avgt    5   1181.710 ±   436.463  ns/op
+Main.noYield                                 3             5  avgt    5    307.035 ±   103.836  ns/op
+Main.noYield                                 3            10  avgt    5    383.382 ±    71.748  ns/op
+Main.noYield                                 3            20  avgt    5    591.850 ±    29.230  ns/op
+Main.noYield                                 3           100  avgt    5   1824.913 ±   445.936  ns/op
+Main.yieldAfterEachCall                      1             5  avgt    5    686.393 ±   329.952  ns/op
+Main.yieldAfterEachCall                      1            10  avgt    5   1034.290 ±   416.330  ns/op
+Main.yieldAfterEachCall                      1            20  avgt    5   1284.444 ±   429.150  ns/op
+Main.yieldAfterEachCall                      1           100  avgt    5  10168.905 ±  5740.237  ns/op
+Main.yieldAfterEachCall                      2             5  avgt    5    713.305 ±   257.892  ns/op
+Main.yieldAfterEachCall                      2            10  avgt    5    913.095 ±   677.172  ns/op
+Main.yieldAfterEachCall                      2            20  avgt    5   1569.985 ±   378.916  ns/op
+Main.yieldAfterEachCall                      2           100  avgt    5   5743.407 ±   361.441  ns/op
+Main.yieldAfterEachCall                      3             5  avgt    5    620.244 ±   118.152  ns/op
+Main.yieldAfterEachCall                      3            10  avgt    5    935.240 ±   229.286  ns/op
+Main.yieldAfterEachCall                      3            20  avgt    5   1435.075 ±   320.586  ns/op
+Main.yieldAfterEachCall                      3           100  avgt    5   7004.200 ±   810.484  ns/op
+Main.yieldBeforeAndAfterEachCall             1             5  avgt    5    807.856 ±   121.607  ns/op
+Main.yieldBeforeAndAfterEachCall             1            10  avgt    5   1583.908 ±   282.423  ns/op
+Main.yieldBeforeAndAfterEachCall             1            20  avgt    5   2958.822 ±   227.041  ns/op
+Main.yieldBeforeAndAfterEachCall             1           100  avgt    5  11921.634 ±  4762.406  ns/op
+Main.yieldBeforeAndAfterEachCall             2             5  avgt    5   1021.651 ±   228.500  ns/op
+Main.yieldBeforeAndAfterEachCall             2            10  avgt    5   1671.527 ±   370.307  ns/op
+Main.yieldBeforeAndAfterEachCall             2            20  avgt    5   2840.464 ±  1130.921  ns/op
+Main.yieldBeforeAndAfterEachCall             2           100  avgt    5  14868.481 ±  1917.354  ns/op
+Main.yieldBeforeAndAfterEachCall             3             5  avgt    5   1423.749 ±   654.309  ns/op
+Main.yieldBeforeAndAfterEachCall             3            10  avgt    5   2079.284 ±  1038.959  ns/op
+Main.yieldBeforeAndAfterEachCall             3            20  avgt    5   5000.881 ±  4475.254  ns/op
+Main.yieldBeforeAndAfterEachCall             3           100  avgt    5  21040.183 ± 15841.209  ns/op
+Main.yieldBeforeEachCall                     1             5  avgt    5    994.679 ±   370.974  ns/op
+Main.yieldBeforeEachCall                     1            10  avgt    5   1256.738 ±   408.932  ns/op
+Main.yieldBeforeEachCall                     1            20  avgt    5   2194.029 ±   416.903  ns/op
+Main.yieldBeforeEachCall                     1           100  avgt    5   8719.001 ±  4205.396  ns/op
+Main.yieldBeforeEachCall                     2             5  avgt    5    811.110 ±   135.250  ns/op
+Main.yieldBeforeEachCall                     2            10  avgt    5   1452.613 ±   299.375  ns/op
+Main.yieldBeforeEachCall                     2            20  avgt    5   2144.500 ±   631.751  ns/op
+Main.yieldBeforeEachCall                     2           100  avgt    5   9879.375 ±  1860.870  ns/op
+Main.yieldBeforeEachCall                     3             5  avgt    5   1037.121 ±   206.179  ns/op
+Main.yieldBeforeEachCall                     3            10  avgt    5   1434.680 ±   476.111  ns/op
+Main.yieldBeforeEachCall                     3            20  avgt    5   2754.720 ±   206.634  ns/op
+Main.yieldBeforeEachCall                     3           100  avgt    5  11498.658 ±  2818.016  ns/op
+Main.yieldThenContinue                       1             5  avgt    5    650.048 ±   105.474  ns/op
+Main.yieldThenContinue                       1            10  avgt    5    774.883 ±   195.603  ns/op
+Main.yieldThenContinue                       1            20  avgt    5    778.199 ±   156.791  ns/op
+Main.yieldThenContinue                       1           100  avgt    5   1664.446 ±   498.033  ns/op
+Main.yieldThenContinue                       2             5  avgt    5    881.937 ±   259.950  ns/op
+Main.yieldThenContinue                       2            10  avgt    5   1376.330 ±  2429.481  ns/op
+Main.yieldThenContinue                       2            20  avgt    5   1279.794 ±   319.451  ns/op
+Main.yieldThenContinue                       2           100  avgt    5   3845.872 ±  1369.059  ns/op
+Main.yieldThenContinue                       3             5  avgt    5   1504.375 ±  2438.227  ns/op
+Main.yieldThenContinue                       3            10  avgt    5   1471.419 ±   440.460  ns/op
+Main.yieldThenContinue                       3            20  avgt    5   2457.391 ±   628.618  ns/op
+Main.yieldThenContinue                       3           100  avgt    5   7104.359 ±  1753.250  ns/op


### PR DESCRIPTION
1. Create a standalone Maven project to meet the needs of JMH, including a pom.xml file, a Java class file, and a txt file which contains the result of the OneShot test
2. Remove the import of jdk.internal.vm.Continuation and jdk.internal.vm.ContinuationScope, which is no need in the test
3. Add a main method to run the JMH benchmarks in Main.java