### PR TITLE
Transplant jtreg test VirtualThreadPinnedEventThrows.java from Loom

### DIFF
--- a/jdk/test/java/lang/VirtualThread/Event.java
+++ b/jdk/test/java/lang/VirtualThread/Event.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * Base class for events, to be subclassed in order to define events and their
+ * fields.
+ */
+public abstract class Event {
+    /**
+     * Sole constructor, for invocation by subclass constructors, typically
+     * implicit.
+     */
+    protected Event() {
+    }
+
+    /**
+     * Starts the timing of this event.
+     */
+    public void begin() {
+    }
+
+    /**
+     * Ends the timing of this event.
+     *
+     * The {@code end} method must be invoked after the {@code begin} method.
+     */
+    public void end() {
+    }
+
+    /**
+     * Writes the field values, time stamp, and event duration.
+     * <p>
+     * If the event starts with an invocation of the {@code begin} method, but does
+     * not end with an explicit invocation of the {@code end} method, then the event
+     * ends when the {@code commit} method is invoked.
+     */
+    public void commit() {
+    }
+
+    /**
+     * Returns {@code true} if the event is enabled, {@code false} otherwise
+     *
+     * @return {@code true} if event is enabled, {@code false} otherwise
+     */
+    public boolean isEnabled() {
+        return false;
+    }
+
+    /**
+     * Returns {@code true} if the event is enabled and if the duration is within
+     * the threshold for the event, {@code false} otherwise.
+     *
+     * @return {@code true} if the event can be written, {@code false} otherwise
+     */
+    public boolean shouldCommit() {
+        return false;
+    }
+
+    /**
+     * Sets a field value.
+     *
+     * @param index the index of the field to set
+     * @param value value to set, can be {@code null}
+     * @throws UnsupportedOperationException if functionality is not supported
+     * @throws IndexOutOfBoundsException if {@code index} is less than {@code 0} or
+     *         greater than or equal to the number of fields specified for the event
+     */
+    public void set(int index, Object value) {
+    }
+}

--- a/jdk/test/java/lang/VirtualThread/VirtualThreadPinnedEvent.java
+++ b/jdk/test/java/lang/VirtualThread/VirtualThreadPinnedEvent.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * VirtualThreadPinnedEvent to optionally throw OOME at create, begin or commit time.
+ */
+public class VirtualThreadPinnedEvent extends Event {
+    private static boolean throwOnCreate;
+    private static boolean throwOnBegin;
+    private static boolean throwOnCommit;
+
+    public static void setCreateThrows(boolean value) {
+        throwOnCreate = value;
+    }
+
+    public static void setBeginThrows(boolean value) {
+        throwOnBegin = value;
+    }
+
+    public static void setCommitThrows(boolean value) {
+        throwOnCommit = value;
+    }
+
+    public VirtualThreadPinnedEvent() {
+        if (throwOnCreate) {
+            throw new OutOfMemoryError();
+        }
+    }
+
+    @Override
+    public void begin() {
+        if (throwOnBegin) {
+            throw new OutOfMemoryError();
+        }
+    }
+
+    @Override
+    public void commit() {
+        if (throwOnCommit) {
+            throw new OutOfMemoryError();
+        }
+    }
+}

--- a/jdk/test/java/lang/VirtualThread/VirtualThreadPinnedEventThrows.java
+++ b/jdk/test/java/lang/VirtualThread/VirtualThreadPinnedEventThrows.java
@@ -21,14 +21,12 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @summary Test parking when pinned and emitting the JFR VirtualThreadPinnedEvent throws
  * @run junit VirtualThreadPinnedEventThrows
  */
 
-// @modules java.base/jdk.internal.event
-// @compile/module=java.base jdk/internal/event/VirtualThreadPinnedEvent.java
 import java.lang.ref.Reference;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
@@ -105,7 +103,6 @@ class VirtualThreadPinnedEventThrows {
             thread.join();
             assertTrue(completed.get());
         } finally {
-//            Reference.reachabilityFence(lock);
         }
     }
 }

--- a/jdk/test/java/lang/VirtualThread/VirtualThreadPinnedEventThrows.java
+++ b/jdk/test/java/lang/VirtualThread/VirtualThreadPinnedEventThrows.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary Test parking when pinned and emitting the JFR VirtualThreadPinnedEvent throws
+ * @run junit VirtualThreadPinnedEventThrows
+ */
+
+// @modules java.base/jdk.internal.event
+// @compile/module=java.base jdk/internal/event/VirtualThreadPinnedEvent.java
+import java.lang.ref.Reference;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.LockSupport;
+//import jdk.internal.event.VirtualThreadPinnedEvent;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class VirtualThreadPinnedEventThrows {
+
+    /**
+     * Test parking when pinned and creating the VirtualThreadPinnedEvent fails with OOME.
+     */
+    @Test
+    void testVirtualThreadPinnedEventCreateThrows() throws Exception {
+        VirtualThreadPinnedEvent.setCreateThrows(true);
+        try {
+            testParkWhenPinned();
+        } finally {
+            VirtualThreadPinnedEvent.setCreateThrows(false);
+        }
+    }
+
+    /**
+     * Test parking when pinned and VirtualThreadPinnedEvent.begin fails with OOME.
+     */
+    @Test
+    void testVirtualThreadPinnedEventBeginThrows() throws Exception {
+        VirtualThreadPinnedEvent.setBeginThrows(true);
+        try {
+            testParkWhenPinned();
+        } finally {
+            VirtualThreadPinnedEvent.setBeginThrows(false);
+        }
+    }
+
+    /**
+     * Test parking when pinned and VirtualThreadPinnedEvent.commit fails with OOME.
+     */
+    @Test
+    void testVirtualThreadPinnedEventCommitThrows() throws Exception {
+        VirtualThreadPinnedEvent.setCommitThrows(true);
+        try {
+            testParkWhenPinned();
+        } finally {
+            VirtualThreadPinnedEvent.setCommitThrows(false);
+        }
+    }
+
+    /**
+     * Test parking a virtual thread when pinned.
+     */
+    private void testParkWhenPinned() throws Exception {
+        Object lock = new Object();
+        try {
+            // var completed = new AtomicBoolean();
+            AtomicBoolean completed = new AtomicBoolean();
+            Thread thread = Thread.startVirtualThread(() -> {
+                synchronized (lock) {
+                    LockSupport.park();
+                    completed.set(true);
+                }
+            });
+
+            // wait for thread to park
+            Thread.State state;
+            while ((state = thread.getState()) != Thread.State.WAITING) {
+                assertTrue(state != Thread.State.TERMINATED);
+                Thread.sleep(10);
+            }
+
+            // unpark and check that thread completed without exception
+            LockSupport.unpark(thread);
+            thread.join();
+            assertTrue(completed.get());
+        } finally {
+//            Reference.reachabilityFence(lock);
+        }
+    }
+}


### PR DESCRIPTION
Code Adjustment

1. Removed `@modules java.base/jdk.internal.event` and `@compile/module=java.base jdk/internal/event/VirtualThreadPinnedEvent.java`, because KonaFiber is not in the current module, adopting the method of directly importing the Event class and VirtualThreadPinnedEvent class.
2. Syntax modification, `var completed = new AtomicBoolean();` changed to `AtomicBoolean completed = new AtomicBoolean();`.
3. Deleted `Reference.reachabilityFence(lock);` as the Reference class in KonaFiber does not have this method.