### PR TITLE
Fix ParallelWorldClassLoader#close to close all JarFiles even on failure

### DIFF
--- a/jaxws/src/share/jaxws_classes/com/sun/istack/internal/tools/ParallelWorldClassLoader.java
+++ b/jaxws/src/share/jaxws_classes/com/sun/istack/internal/tools/ParallelWorldClassLoader.java
@@ -197,9 +197,19 @@ public class ParallelWorldClassLoader extends ClassLoader implements Closeable {
     }
 
     public synchronized void close() throws IOException {
+        IOException ioe = null;
         for (JarFile jar : jars) {
-            jar.close();
+            try {
+                jar.close();
+            } catch (IOException e) {
+                if (ioe == null) {
+                    ioe = e;
+                } else {
+                    ioe.ddSuppressed(e);
+                }
+            }
         }
+        if (ioe != null) return ioe;
     }
 
     /**


### PR DESCRIPTION
### Problem
`ParallelWorldClassLoader#close()` attempts to close all tracked JarFile instances. it closes them sequentially without handling exceptions. If one close() throws, the method exits immediately and the remaining JarFiles are never closed.

### Fix
- Wrap each `jar.close()` in a try/catch.
- Continue closing the remaining streams even after a failure.
- After attempting all closes, throw the first exception (and attach later ones as suppressed, if present).